### PR TITLE
unset session token

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -11,6 +11,7 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
   echo "Enter MFA token code:"
   read tokenCode
   unset AWS_SECURITY_TOKEN
+  unset AWS_SESSION_TOKEN
   if [ -z "$AWS_ENV_VARS" ]; then
     if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
       export AWS_ENV_VARS="True"


### PR DESCRIPTION
The script currently sets `$AWS_SESSION_TOKEN`, but fails to unset it when beginning a new session. This breaks things for people like myself that manage my IAM credentials in environment variables.
