### PR TITLE
Force sts to output in json format.

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -38,7 +38,8 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
   serialArn+="$username"
 
   commandResult=" "
-  commandResult+=$(aws sts assume-role --role-arn $roleArn \
+  commandResult+=$(aws sts assume-role --output json \
+                  --role-arn $roleArn \
                   --role-session-name iam-role-injector \
                   --serial-number $serialArn \
                   --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]' \


### PR DESCRIPTION
Any other formats will cause silent failure and a value passed to an AWS CLI command with --output overrides any value set in the environment or in the config file.

http://docs.aws.amazon.com/cli/latest/userguide/controlling-output.html
