### PR TITLE
Proper exit codes

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -45,6 +45,7 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
                   --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]' \
                   --token-code $tokenCode)
 
+  exitCode=$?
   size=${#commandResult}
   if (( $size > 5 )); then
     commandResult1=$(echo "$commandResult" | sed '5d' | sed '1d' | tr -d '\040\011\012\015' | sed 's/\"//g')
@@ -58,8 +59,14 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
     export AWS_SESSION_TOKEN=$arg2
     arg3=$(echo "$commandResult1" | cut -d "," -f3)
     export AWS_ACCESS_KEY_ID=$arg3
-  fi
+  else
+    echo "Unable to assume role"
+    exitCode=1
+  if
+
+  (exit $exitCode)
 
 else
   echo "Usage: source assume_role.sh {sourceAccountNumber} {username} {destinationAccountNumber} {rolename}"
+  (exit 1)
 fi

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -62,7 +62,7 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
   else
     echo "Unable to assume role"
     exitCode=1
-  if
+  fi
 
   (exit $exitCode)
 

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -46,6 +46,7 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
                   --token-code $tokenCode)
 
   exitCode=$?
+
   size=${#commandResult}
   if (( $size > 5 )); then
     commandResult1=$(echo "$commandResult" | sed '5d' | sed '1d' | tr -d '\040\011\012\015' | sed 's/\"//g')
@@ -64,9 +65,11 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
     exitCode=1
   fi
 
-  (exit $exitCode)
-
 else
   echo "Usage: source assume_role.sh {sourceAccountNumber} {username} {destinationAccountNumber} {rolename}"
-  (exit 1)
+  exitCode=1
 fi
+
+# This runs in a subshell, so it will not exit your shell when you are sourcing,
+# but it still gives you the correct exit code if you read from $?
+(exit $exitCode)


### PR DESCRIPTION
Runs a command in a subshell so coming back from `source ...` has the proper exit code.