### PR TITLE
Script Redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,33 @@ command line tools to assume a role.
    Variables or through 'aws configure'
 3. `wget -N https://raw.githubusercontent.com/civisanalytics/iam-role-injector/master/assume_role.sh -O ~/assume_role.sh`
 
+## Increase AWS IAM Role max-session-duration
+1 hour is used by default (following the AWS assume-role default), if no timeout time is specified.
+To update an AWS IAM role beyond 1 hour using the sts assume-role call, you must initially update the IAM role with a max-session-duration (in seconds).
+e.g. (for 12 hours):
+
+`aws iam update-role --role-name administrator --max-session-duration 43200`
+
 ## Command Line Usage
 
+`source /path/to/sts_assume_role.sh -d 1234567890 -r administrator`
+
+*source /path/to/sts_assume_role.sh -d [destination_account__number] -r [rolename]*
+### Otional features:
+#### Help menu
+`/path/to/sts_assume_role.sh -h`
+#### Show current iam user or role info
+`/path/to/sts_assume_role.sh -i`
+#### Revert to iam user from role
+`/path/to/sts_assume_role.sh -u`
+#### Specify expiration (aws sts now supports from 1 hour, up to 12 hours)
+`source /path/to/sts_assume_role.sh -d [destination_account__number] -r [rolename] -t 4h`
+
+*(works with seconds, minutes, or hours. e.g. `-t 2h` `-t 120m` `-t 7200s` `-t 7200`)*
+
+
+
+# Antiquated script
 ```
 source ~/assume_role.sh {sourceAccountNumber} {username} {destinationAccountNumber} {rolename}
 ```

--- a/README.md
+++ b/README.md
@@ -54,9 +54,45 @@ e.g. (for 12 hours):
 #### Specify expiration (aws sts now supports from 1 hour, up to 12 hours)
 `source /path/to/sts_assume_role.sh -d [destination_account__number] -r [rolename] -t 4h`
 
-*(works with seconds, minutes, or hours. e.g. `-t 2h` `-t 120m` `-t 7200s` `-t 7200`)*
+*works with seconds, minutes, or hours. e.g. `-t 2h` `-t 120m` `-t 7200s` `-t 7200`*
 
+### Variables exported
+```
+AWS_ACCOUNT_NAME
+AWS_ACCESS_KEY_ID
+AWS_ENV_VARS
+AWS_SECRET_ACCESS_KEY
+AWS_SECURITY_TOKEN
+AWS_SESSION_TOKEN
+AWS_STS_EXPIRATION
+AWS_STS_TIMEOUT
+AWS_USER
+OG_AWS_ACCESS_KEY_ID
+OG_AWS_SECRET_ACCESS_KEY
+```
 
+### Expiration/Timeout use case
+`AWS_STS_EXPIRATION` and `AWS_STS_TIMEOUT` are helpful to create a basic functions to determine how much time until the assume-role has
+expired.
+
+```
+function timeToSTSExpiration(){
+  echo $(( $(( ${AWS_STS_TIMEOUT} - $(date -u +%s) )) / 60 ))
+}
+```
+
+It can even be added to your prompt. e.g.
+```
+function checkSTS() {
+if [[ -n $AWS_STS_EXPIRATION && $AWS_STS_TIMEOUT -ge $(date +%s) ]]; then
+  AWS_STS_MINUTES_REMAINING=$(( $(( AWS_STS_TIMEOUT - $(date -u +%s) )) / 60 ))
+  echo "$AWS_ACCOUNT_NAME|$AWS_STS_MINUTES_REMAINING"
+elif [[ $AWS_STS_TIMEOUT -le $(date +%s) ]]; then
+  unset AWS_STS_EXPIRATION
+fi
+STS_PROMPT_="$STS_COLOR"'$(checkSTS)'
+PROMPT="$STS_PROMPT >"
+```
 
 # Antiquated script
 ```

--- a/README.md
+++ b/README.md
@@ -41,20 +41,50 @@ e.g. (for 12 hours):
 
 ## Command Line Usage
 
+*source /path/to/sts_assume_role.sh -d [destination_account__number] -r [rolename]*
+
+e.g.
 `source /path/to/sts_assume_role.sh -d 1234567890 -r administrator`
 
-*source /path/to/sts_assume_role.sh -d [destination_account__number] -r [rolename]*
+e.g.
+`source /path/to/sts_assume_role.sh --source 9876543210 --user iam-user --destination 1234567890 --role administrator --timeout 6h --mfa 552255`
+
 ### Otional features:
 #### Help menu
-`/path/to/sts_assume_role.sh -h`
+```
+/path/to/sts_assume_role.sh -h
+[Help Menu Options]
+Specify at least a role (-r) and destination account (-d)
+    -d|--destination    to which AWS account you will assume-role
+    -h|--help           (this) help menu
+    -i|--info           output aws Info
+    -m|--mfa            multi-factor (2fa/mfa) authentication (default is NONE)
+    -r|--role           aws role you wish be become
+    -s|--source         source account id (not needed if you can 'aws iam list-account-aliases')
+    -t|--timeout        duration in which assume-role will be functional
+                        (values in (s)econds,(m)inutes,(h)ours - 60m up to 12h. Default is 3600s)
+    -u|--user           iam user name (not needed if you can 'aws sts get-caller-identity')
+    -x|--unset          unset assumed role vars
+```
+
 #### Show current iam user or role info
 `/path/to/sts_assume_role.sh -i`
 #### Revert to iam user from role
 `/path/to/sts_assume_role.sh -u`
 #### Specify expiration (aws sts now supports from 1 hour, up to 12 hours)
 `source /path/to/sts_assume_role.sh -d [destination_account__number] -r [rolename] -t 4h`
-
 *works with seconds, minutes, or hours. e.g. `-t 2h` `-t 120m` `-t 7200s` `-t 7200`*
+### Specify nothing, and you will be prompted for necessary information
+```
+source /path/to/sts_assume_role.sh
+[No values set, please enter at least the destination account number and role name to assume a role]
+Source Account (Default is NONE): 9876543210
+Destination Account: 1234567890
+IAM User Name (Default is NONE): iam-user
+Role: administrator
+Timeout (Default is 1h):
+Multifactor Authentication? (default is NONE):
+```
 
 ### Variables exported
 ```

--- a/sts_assume_role.sh
+++ b/sts_assume_role.sh
@@ -179,20 +179,21 @@ print_help(){
 rotate_keys(){
     unset AWS_SECURITY_TOKEN
     unset AWS_SESSION_TOKEN
-    if [ "$AWS_ENV_VARS" != True ]; then
-        if [ ! "$AWS_SECRET_ACCESS_KEY" ]; then
-            export AWS_ENV_VARS="True"
-        elif [ ! "$OG_AWS_SECRET_ACCESS_KEY" ]; then
-            export OG_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-            export OG_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-        else
-            export AWS_SECRET_ACCESS_KEY=$OG_AWS_SECRET_ACCESS_KEY
-            export AWS_ACCESS_KEY_ID=$OG_AWS_ACCESS_KEY_ID
-            unset AWS_ENV_VARS
-        fi
+
+    if [ -z "$AWS_ENV_VARS" ]; then
+      if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+        export AWS_ENV_VARS="True"
+      elif [ -z "$OG_AWS_SECRET_ACCESS_KEY" ]; then
+        export OG_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+        export OG_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+      else
+        export AWS_SECRET_ACCESS_KEY=$OG_AWS_SECRET_ACCESS_KEY
+        export AWS_ACCESS_KEY_ID=$OG_AWS_ACCESS_KEY_ID
+        unset AWS_ENV_VARS
+      fi
     else
-        unset AWS_SECRET_ACCESS_KEY
-        unset AWS_ACCESS_KEY_ID
+      unset AWS_SECRET_ACCESS_KEY
+      unset AWS_ACCESS_KEY_ID
     fi
 }
 

--- a/sts_assume_role.sh
+++ b/sts_assume_role.sh
@@ -16,6 +16,8 @@ arg_vars(){
         -m|--mfa )
             mfatoken="$2" ;;
     esac
+    [ "$mfatoken" ] || \
+        mfatoken=NONE
 }
 
 assume_role(){
@@ -99,7 +101,6 @@ parse_args(){
         prompt_args
     else
         TIMEOUT=3600
-        mfatoken=NONE
         while [ $# -ne 0 ]; do
             arg_vars "$@"
             shift
@@ -109,16 +110,20 @@ parse_args(){
 
 prompt_args(){
     # Prompt user if no args specified
-    # read -rp "Source Account: " S
     printf "Destination Account: "
     read -r destinationaccount
     printf "Role: "
     read -r rolename
     printf "Timeout (Default: 1hr): "
     read -r timeout
-    printf "Multifactor Authentication?: (default is NONE)"
+    printf "Multifactor Authentication? (default is NONE): "
     read -r mfa
-    parse_args -d "$destinationaccount" -r "$rolename" -t "$timeout" -t "$mfa"
+    if [ -n "$mfa" ]; then
+        mfatoken="$mfa"
+    else
+        mfatoken=NONE
+    fi
+    main -d "$destinationaccount" -r "$rolename" -t "$timeout" -m "$mfa"
 }
 
 print_help(){
@@ -209,4 +214,4 @@ main(){
 main "$@"
 # This runs in a subshell, so it will not exit your shell when you are sourcing,
 # but it still gives you the correct exit code if you read from $?
-(exit $exitCode)
+(exit "$exitCode")

--- a/sts_assume_role.sh
+++ b/sts_assume_role.sh
@@ -39,6 +39,7 @@ assume_role(){
         roleCommand+="--token-code $mfatoken"
 
     commandResult=$(eval "$roleCommand")
+    exitCode=$?
     if [[ "$commandResult" && ${#commandResult} -gt 6 ]]; then
         arg1=$(echo "$commandResult" | awk -F\" 'NR==2 {print $2}')
         arg2=$(echo "$commandResult" | awk -F\" 'NR==3 {print $2}')
@@ -57,6 +58,7 @@ assume_role(){
         echo -e "$AWS_ACCOUNT_NAME:$rolename\nexpiration: $AWS_STS_EXPIRATION UTC"
     else
         echo
+        exitCode=1
         main -h
     fi
 }
@@ -80,6 +82,7 @@ get_aws_info(){
     [ "$AWS_ACCESS_KEY_ID" ] || \
         AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile default) \
         AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile default)
+    exitCode=$1
 }
 
 header(){
@@ -204,3 +207,6 @@ main(){
 }
 
 main "$@"
+# This runs in a subshell, so it will not exit your shell when you are sourcing,
+# but it still gives you the correct exit code if you read from $?
+(exit $exitCode)

--- a/sts_assume_role.sh
+++ b/sts_assume_role.sh
@@ -10,7 +10,8 @@ arg_vars(){
         -d|--destination )
             DESTINATION_ACCOUNT="$2" ;;
         -m|--mfa )
-            MFA_TOKEN="$2" ;;
+            get_mfa_token "$2" && \
+                [ -z "$MFA_TOKEN" ] && MFA_TOKEN=NONE ;;
         -r|--role )
             ROLE_NAME="$2" ;;
         -s|--source )
@@ -111,6 +112,15 @@ get_aws_info(){
     fi
 }
 
+get_mfa_token(){
+    if [ -z "$*" ]; then
+        printf "Please enter your multifactor token code (default is NONE): "
+        read -r MFA_TOKEN
+    else
+        MFA_TOKEN="$*"
+    fi
+}
+
 header(){
     echo -e "[${PURPLE}${1}${WHITE}]"
 }
@@ -125,7 +135,6 @@ parse_args(){
         prompt_args
     else
         TIMEOUT=3600
-        MFA_TOKEN=NONE
         while [ $# -ne 0 ]; do
             arg_vars "$@"
             shift
@@ -184,7 +193,6 @@ rotate_keys(){
     else
         unset AWS_SECRET_ACCESS_KEY
         unset AWS_ACCESS_KEY_ID
-        unset AWS_USER
     fi
 }
 

--- a/sts_assume_role.sh
+++ b/sts_assume_role.sh
@@ -16,8 +16,6 @@ arg_vars(){
         -m|--mfa )
             mfatoken="$2" ;;
     esac
-    [ "$mfatoken" ] || \
-        mfatoken=NONE
 }
 
 assume_role(){
@@ -84,7 +82,7 @@ get_aws_info(){
     [ "$AWS_ACCESS_KEY_ID" ] || \
         AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile default) \
         AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile default)
-    exitCode=$1
+    exitCode=1
 }
 
 header(){
@@ -101,6 +99,7 @@ parse_args(){
         prompt_args
     else
         TIMEOUT=3600
+        mfatoken=NONE
         while [ $# -ne 0 ]; do
             arg_vars "$@"
             shift
@@ -110,6 +109,7 @@ parse_args(){
 
 prompt_args(){
     # Prompt user if no args specified
+    header "No values set, please enter at least the destination account number and role name to assume"
     printf "Destination Account: "
     read -r destinationaccount
     printf "Role: "
@@ -118,11 +118,6 @@ prompt_args(){
     read -r timeout
     printf "Multifactor Authentication? (default is NONE): "
     read -r mfa
-    if [ -n "$mfa" ]; then
-        mfatoken="$mfa"
-    else
-        mfatoken=NONE
-    fi
     main -d "$destinationaccount" -r "$rolename" -t "$timeout" -m "$mfa"
 }
 
@@ -214,4 +209,4 @@ main(){
 main "$@"
 # This runs in a subshell, so it will not exit your shell when you are sourcing,
 # but it still gives you the correct exit code if you read from $?
-(exit "$exitCode")
+(exit $exitCode)

--- a/sts_assume_role.sh
+++ b/sts_assume_role.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+PURPLE="\033[35m"
+WHITE="\033[0m"
+
+
+arg_vars(){
+    # Set aws args
+    case "$1" in
+        -d|--destination )
+            destinationaccount="$2" ;;
+        -t|--timeout )
+            timeout_time "$2" ;;
+        -r|--role )
+            rolename="$2" ;;
+        -m|--mfa )
+            mfatoken="$2" ;;
+    esac
+}
+
+assume_role(){
+    header "AWS STS assume-role"
+    roleArn="arn:aws:iam::"
+    roleArn+="$destinationaccount"
+    roleArn+=":role/"
+    roleArn+="$rolename"
+
+    serialArn="arn:aws:iam::"
+    serialArn+="$AWS_ACCOUNT_NUMBER"
+    serialArn+=":mfa/"
+    serialArn+="$AWS_USER"
+
+    roleCommand="aws sts assume-role --role-arn $roleArn "
+    roleCommand+="--role-session-name iam-role-injector "
+    roleCommand+="--duration-seconds $AWS_STS_TIMEOUT "
+    roleCommand+="--serial-number $serialArn "
+    roleCommand+="--query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId, Expiration]' "
+    [ "$mfatoken" != NONE ] && \
+        roleCommand+="--token-code $mfatoken"
+
+    commandResult=$(eval "$roleCommand")
+    if [[ "$commandResult" && ${#commandResult} -gt 6 ]]; then
+        arg1=$(echo "$commandResult" | awk -F\" 'NR==2 {print $2}')
+        arg2=$(echo "$commandResult" | awk -F\" 'NR==3 {print $2}')
+        arg3=$(echo "$commandResult" | awk -F\" 'NR==4 {print $2}')
+        arg4=$(echo "$commandResult" | awk -F\" 'NR==5 {print $2}')
+        # Set AWS_SESSION_TOKEN and AWS_SECURITY_TOKEN for backwards compatibility
+        # See: http://boto3.readthedocs.org/en/latest/guide/configuration.html
+        export AWS_SECRET_ACCESS_KEY="$arg1"
+        export AWS_SECURITY_TOKEN="$arg2"
+        export AWS_SESSION_TOKEN="$arg2"
+        export AWS_ACCESS_KEY_ID="$arg3"
+        export AWS_STS_EXPIRATION="$arg4"
+        AWS_STS_TIMEOUT=$(date -ujf "%Y-%m-%dT%H:%M:%SZ" "$AWS_STS_EXPIRATION" "+%s") # reassign var to epoch timestamp
+        export AWS_STS_TIMEOUT
+        AWS_ACCOUNT_NAME=$(aws iam list-account-aliases --query 'AccountAliases[]' --output text)
+        export AWS_ACCOUNT_NAME
+        echo "$AWS_ACCOUNT_NAME:$rolename\nexpiration: $AWS_STS_EXPIRATION UTC"
+    else
+        echo
+        main -h
+    fi
+}
+
+get_aws_info(){
+    AWS_ACCOUNT_NAME=$(aws iam list-account-aliases --query 'AccountAliases[]' --output text)
+    AWS_INFO=$(aws sts get-caller-identity --output text --query '[Account, Arn]')
+    AWS_ACCOUNT_NUMBER=$(awk '{print $1}' <<< "$AWS_INFO")
+    AWS_USER=$(awk -F"/" '{print $2}' <<< "$AWS_INFO")
+    [ "$AWS_ACCESS_KEY_ID" ] || \
+        AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile default) \
+        AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile default)
+}
+
+header(){
+    echo -e "[${PURPLE}${1}${WHITE}]"
+}
+
+print_aws_info(){
+    get_aws_info
+    echo "$AWS_ACCOUNT_NUMBER $AWS_ACCOUNT_NAME/$AWS_USER: $AWS_ACCESS_KEY_ID"
+}
+
+parse_args(){
+    if [ $# -eq 0 ]; then
+        prompt_args
+    else
+        AWS_STS_TIMEOUT=3600
+        mfatoken=NONE
+        while [ $# -ne 0 ]; do
+            arg_vars "$@"
+            shift
+        done
+    fi
+}
+
+prompt_args(){
+    # Prompt user if no args specified
+    # read -rp "Source Account: " S
+    printf "Destination Account: "
+    read -r destinationaccount
+    printf "Role: "
+    read -r rolename
+    printf "Timeout (Default: 1hr): "
+    read -r timeout
+    printf "Multifactor Authentication?: (default is NONE)"
+    read -r mfa
+    parse_args -d "$destinationaccount" -r "$rolename" -t "$timeout" -t "$mfa"
+}
+
+print_help(){
+    header "Help Menu Options"
+    echo \
+    "Specify at least a role (-r) and destination account (-d)
+    -d|--destination    to which AWS account you will assume-role
+    -h|--help           (this) help menu
+    -i|--info           output aws Info
+    -m|--mfa            disable multi-factor (2fa/mfa) authentication (unspecified defaults to NONE)
+    -r|--role           aws role you wish be become
+    -t|--timeout        duration in which assume-role will be functional
+                        (values in (s)econds,(m)inutes,(h)ours - 60m up to 12h. Default is 3600s)
+    -u|--unset          unset assumed role vars"
+}
+
+rotate_keys(){
+    unset AWS_SECURITY_TOKEN
+    unset AWS_SESSION_TOKEN
+    if [ "$AWS_ENV_VARS" != True ]; then
+        if [ ! "$AWS_SECRET_ACCESS_KEY" ]; then
+            export AWS_ENV_VARS="True"
+        elif [ ! "$OG_AWS_SECRET_ACCESS_KEY" ]; then
+            export OG_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+            export OG_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+        else
+            export AWS_SECRET_ACCESS_KEY=$OG_AWS_SECRET_ACCESS_KEY
+            export AWS_ACCESS_KEY_ID=$OG_AWS_ACCESS_KEY_ID
+            unset AWS_ENV_VARS
+        fi
+    else
+        unset AWS_SECRET_ACCESS_KEY
+        unset AWS_ACCESS_KEY_ID
+        unset AWS_USER
+    fi
+}
+
+timeout_time(){
+    if [ "$1" ]; then
+        if [[ "$1" =~ h$\|H$ ]]; then
+            AWS_STS_TIMEOUT="$(( ${1%?} * 60 * 60))"
+        elif [[ "$1" =~ m$\|M$ ]]; then
+            AWS_STS_TIMEOUT="$(( ${1%?} * 60))"
+        elif [[ "$1" =~ s$\|S$ ]]; then
+            AWS_STS_TIMEOUT="${1%?}"
+        elif [[ "$1" =~ [0-9]$ ]]; then
+            AWS_STS_TIMEOUT="$1"
+        fi
+    else
+        AWS_STS_TIMEOUT=3600
+    fi
+}
+
+unset_vars(){
+    header "Reverting assume-role vars back to IAM user";
+    unset AWS_INFO \
+        AWS_ACCOUNT_NAME \
+        AWS_ACCOUNT_NUMBER \
+        AWS_SECURITY_TOKEN \
+        AWS_SESSION_TOKEN \
+        AWS_STS_EXPIRATION \
+        AWS_STS_TIMEOUT \
+        AWS_USER
+        print_aws_info
+}
+
+main(){
+    case "$1" in
+        -h|--help )
+            print_help ;;
+        -i|--info )
+            header "Current AWS Info"
+            print_aws_info ;;
+        -u|--unset )
+            rotate_keys
+            unset_vars ;;
+        "" )
+            prompt_args ;;
+        * )
+            parse_args "$@" && \
+            rotate_keys && \
+            get_aws_info && \
+            assume_role
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
AWS STS assume-role now supports assumed roles up to [12 hours](https://aws.amazon.com/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/). I've kept the previous script in tact, in case users will want to make use of it for the time being. The `sts_assume_role.sh` script has been added to offer additional features
- define specified timeout duration
- built in help menu
- get info for current iam user or role
- unset role creds to revert to iam user
- source account and user are determined by the aws access keypair being used, so they are no longer required
- multi-factor authentication is optional when specified by `-m` or `--mfa`

I've also tested compatibility on MacOS as well as Ubuntu and Centos.

1 hour is used by default (following the AWS assume-role default), if no timeout time is specified. To update an AWS IAM role for >1 hour using the sts assume-role call, you must initially update the IAM role with a max-session-duration (in seconds). e.g. (for 12 hours):
`aws iam update-role --role-name administrator --max-session-duration 43200`