### PR TITLE
[HACK-446] refactor assume_role for functions & duration-seconds

### DIFF
--- a/assume_role.sh
+++ b/assume_role.sh
@@ -37,43 +37,21 @@ get_sts () {
   echo "Enter MFA token code:"
   read tokenCode
 
-  case "$scriptArgs" in
-    4)
-      if [ -z "$tokenCode" ]; then
-        read -a commandResult <<< $(aws sts assume-role --output text\
-                      --role-arn $roleArn \
-                      --role-session-name iam-role-injector \
-                      --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]')
-      else
-        read -a commandResult <<< $(aws sts assume-role --output text \
-                      --role-arn $roleArn \
-                      --role-session-name iam-role-injector \
-                      --serial-number $serialArn \
-                      --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]' \
-                      --token-code $tokenCode)
-      fi
-      ;;
-    5)
-      if [ -z "$tokenCode" ]; then
-        read -a commandResult <<< $(aws sts assume-role --output text\
-                      --role-arn $roleArn \
-                      --role-session-name iam-role-injector \
-                      --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]' \
-                      --duration-seconds $durationSeconds)
-      else
-        read -a commandResult <<< $(aws sts assume-role --output text \
-                      --role-arn $roleArn \
-                      --role-session-name iam-role-injector \
-                      --serial-number $serialArn \
-                      --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]' \
-                      --duration-seconds $durationSeconds \
-                      --token-code $tokenCode)
-      fi
-      ;;
-      *)
-        echo "Could not form sts assume-role command! Check arguments."
-        exitCode=1
-  esac
+  if [ -z "$tokenCode" ]; then
+    read -a commandResult <<< $(aws sts assume-role --output text\
+                  --role-arn $roleArn \
+                  --role-session-name iam-role-injector \
+                  --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]' \
+                  --duration-seconds $durationSeconds)
+  else
+    read -a commandResult <<< $(aws sts assume-role --output text \
+                  --role-arn $roleArn \
+                  --role-session-name iam-role-injector \
+                  --serial-number $serialArn \
+                  --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]' \
+                  --duration-seconds $durationSeconds \
+                  --token-code $tokenCode)
+  fi
 
   exitCode=$?
 }

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -2,13 +2,11 @@
 # requires 4 args and optionally a 5th, needs to be run with source to get exported variables to stick
 # source assume_role.sh <sourceAccountNumber> <username> <destinationAccountNumber> <rolename> [durationSeconds]
 
-scriptArgs=$#
 sourceAccountNumber=$1
 username=$2
 destinationAccountNumber=$3
 rolename=$4
 durationSeconds=${5:-3600}
-exitCode=""
 
 roleArn="arn:aws:iam::${destinationAccountNumber}:role/${rolename}"
 serialArn="arn:aws:iam::${sourceAccountNumber}:mfa/${username}"

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -1,51 +1,47 @@
 # USAGE:
-# requires 4 args, needs to be run with source to get exported variables to stick
-# source assume_role.sh {sourceAccountNumber} {username} {destinationAccountNumber} {rolename}
+# requires 4 args and optionally a 5th, needs to be run with source to get exported variables to stick
+# source assume_role.sh <sourceAccountNumber> <username> <destinationAccountNumber> <rolename> [durationSeconds]
+
 
 sourceAccountNumber=$1
 username=$2
 destinationAccountNumber=$3
 rolename=$4
+durationSeconds=${5:-3600}
 
-if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "$rolename" ] && [ -n "$username" ]; then
+roleArn="arn:aws:iam::${destinationAccountNumber}:role/${rolename}"
+serialArn="arn:aws:iam::${sourceAccountNumber}:mfa/${username}"
+
+clear_env_vars () {
+    unset AWS_SECURITY_TOKEN
+    unset AWS_SESSION_TOKEN
+    if [ -z "$AWS_ENV_VARS" ]; then
+      if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+        export AWS_ENV_VARS="True"
+      elif [ -z "$OG_AWS_SECRET_ACCESS_KEY" ]; then
+        export OG_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+        export OG_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+      else
+        export AWS_SECRET_ACCESS_KEY=$OG_AWS_SECRET_ACCESS_KEY
+        export AWS_ACCESS_KEY_ID=$OG_AWS_ACCESS_KEY_ID
+      fi
+    else
+      unset AWS_SECRET_ACCESS_KEY
+      unset AWS_ACCESS_KEY_ID
+    fi
+}
+
+get_sts () {
+  # allow a blank tokenCode for orgs that don't use an MFA
   echo "Enter MFA token code:"
   read tokenCode
-  unset AWS_SECURITY_TOKEN
-  unset AWS_SESSION_TOKEN
-  if [ -z "$AWS_ENV_VARS" ]; then
-    if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-      export AWS_ENV_VARS="True"
-    elif [ -z "$OG_AWS_SECRET_ACCESS_KEY" ]; then
-      export OG_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-      export OG_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-    else
-      export AWS_SECRET_ACCESS_KEY=$OG_AWS_SECRET_ACCESS_KEY
-      export AWS_ACCESS_KEY_ID=$OG_AWS_ACCESS_KEY_ID
-    fi
-  else
-    unset AWS_SECRET_ACCESS_KEY
-    unset AWS_ACCESS_KEY_ID
-  fi
-
-  roleArn="arn:aws:iam::"
-  roleArn+="$destinationAccountNumber"
-  roleArn+=":role/"
-  roleArn+="$rolename"
-
-  serialArn="arn:aws:iam::"
-  serialArn+="$sourceAccountNumber"
-  serialArn+=":mfa/"
-  serialArn+="$username"
-
-  commandResult=" "
-  # allow a blank tokenCode for orgs that don't use an MFA
   if [ -z "$tokenCode" ]; then
-    commandResult+=$(aws sts assume-role --output json \
+    read -a commandResult <<< $(aws sts assume-role --output text\
                   --role-arn $roleArn \
                   --role-session-name iam-role-injector \
                   --query 'Credentials.[SecretAccessKey, SessionToken, AccessKeyId]')
   else
-    commandResult+=$(aws sts assume-role --output json \
+    read -a commandResult <<< $(aws sts assume-role --output text \
                   --role-arn $roleArn \
                   --role-session-name iam-role-injector \
                   --serial-number $serialArn \
@@ -53,31 +49,37 @@ if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "
                   --token-code $tokenCode)
   fi
 
-  exitCode=$?
+  global exitCode=$?
+}
 
-  size=${#commandResult}
-  if (( $size > 5 )); then
-    commandResult1=$(echo "$commandResult" | sed '5d' | sed '1d' | tr -d '\040\011\012\015' | sed 's/\"//g')
+set_env_vars () {
+  if (( ${#commandResult[@]} == 3 )); then
     echo "You have assumed the $rolename role successfully."
-    arg1=$(echo "$commandResult1" | cut -d "," -f1)
-    export AWS_SECRET_ACCESS_KEY=$arg1
-    arg2=$(echo "$commandResult1" | cut -d "," -f2)
+    export AWS_SECRET_ACCESS_KEY=${commandResult[0]}
     # Set AWS_SESSION_TOKEN and AWS_SECURITY_TOKEN for backwards compatibility
     # See: http://boto3.readthedocs.org/en/latest/guide/configuration.html
-    export AWS_SECURITY_TOKEN=$arg2
-    export AWS_SESSION_TOKEN=$arg2
-    arg3=$(echo "$commandResult1" | cut -d "," -f3)
-    export AWS_ACCESS_KEY_ID=$arg3
+    export AWS_SECURITY_TOKEN=${commandResult[1]}
+    export AWS_SESSION_TOKEN=${commandResult[1]}
+    export AWS_ACCESS_KEY_ID=${commandResult[2]}
   else
     echo "Unable to assume role"
-    exitCode=1
+    global exitCode=1
   fi
+}
 
+main () {
+if [ -n "$destinationAccountNumber" ] && [ -n "$sourceAccountNumber" ] && [ -n "$rolename" ] && [ -n "$username" ]; then
+ clear_env_vars
+ get_sts
+ set_env_vars
 else
-  echo "Usage: source assume_role.sh {sourceAccountNumber} {username} {destinationAccountNumber} {rolename}"
+  echo "Usage: source assume_role.sh <sourceAccountNumber> <username> <destinationAccountNumber> <rolename> [durationSeconds]"
   exitCode=1
 fi
 
 # This runs in a subshell, so it will not exit your shell when you are sourcing,
 # but it still gives you the correct exit code if you read from $?
-(exit $exitCode)
+}
+
+main
+(exit $?)


### PR DESCRIPTION
This change does a few things:

* adds an optional fifth parameter to configure how long (in seconds) the token should be valid for
* simplifies some of the logic
* moves commands into functions for ease of unit testing (which will be added in a future PR)

It was tested by temporarily adding `set -x` to ensure the output was as expected, and then confirmed by assuming a role and running commands with it.